### PR TITLE
Add jQuery-Waypoints For Sticky fullstatement.html Nav

### DIFF
--- a/fullstatement.html
+++ b/fullstatement.html
@@ -26,10 +26,17 @@
 	<script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
 	<script src="js/page-nav.js" type="text/javascript"></script>
 	<script src="http://git.joahg.com/bibleRef.js/bibleRef.min.js" type="text/javascript"></script>
+	<script src="http://imakewebthings.com/jquery-waypoints/waypoints.js" type="text/javascript"></script>
+	<script src="http://imakewebthings.com/jquery-waypoints/shortcuts/sticky-elements/waypoints-sticky.min.js" type="text/javascript"></script>
 	<script>
 		bibleRef = {
 			target: '_blank'
 		};
+		$(document).ready(function(){
+			$('.sidebar').waypoint('sticky', {
+				offset: 30
+			});
+		});
 	</script>
 
 	<!--[if lt IE 9]>

--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -85,6 +85,11 @@ ul a {
 	line-height: 1.8em;
 }
 
+.stuck {
+	position: fixed;
+	top: 30px;
+}
+
 nav:not(.sidebar) a {
 	display: inline-block;
 	width: 13%;


### PR DESCRIPTION
On `fullstatement.html`, because the page is set up in such a way that the user will be jumping all over the page with the initial sidebar nav (good job, btw, creating the generator for that - that looks nice ;)), I think it would be a good idea to add jQuery Waypoints in to make the `nav.sidebar` sticky once the user scrolls down to it.
